### PR TITLE
Fix the log_file option name

### DIFF
--- a/runironicagent
+++ b/runironicagent
@@ -3,7 +3,7 @@
 cat > /etc/ironic-python-agent/ironic-python-agent.conf <<EOF
 [DEFAULT]
 debug = True
-log-file = /var/log/ironic-python-agent.log
+log_file = /var/log/ironic-python-agent.log
 use_stderr = True
 EOF
 


### PR DESCRIPTION
Despite what oslo.log has in its code and documents, it uses
underscores, not dashes.
