### PR TITLE
Allow additional CoreOS configuration via environment

### DIFF
--- a/hardware_manager/ironic_coreos_install.py
+++ b/hardware_manager/ironic_coreos_install.py
@@ -80,6 +80,10 @@ class CoreOSInstallHardwareManager(hardware.HardwareManager):
         else:
             args += ['--offline']
 
+        ip_args = os.getenv('IPA_COREOS_IP_OPTIONS')
+        if ip_args:
+            args += ['--append-karg', ip_args]
+
         copy_network = meta_data.get('coreos_copy_network', True)
         if copy_network:
             args += ['--copy-network']

--- a/hardware_manager/ironic_coreos_install.py
+++ b/hardware_manager/ironic_coreos_install.py
@@ -84,7 +84,8 @@ class CoreOSInstallHardwareManager(hardware.HardwareManager):
         if ip_args:
             args += ['--append-karg', ip_args]
 
-        copy_network = meta_data.get('coreos_copy_network', True)
+        copy_network = meta_data.get('coreos_copy_network',
+                os.getenv('IPA_COREOS_COPY_NETWORK', '').lower() == 'true')
         if copy_network:
             args += ['--copy-network']
 


### PR DESCRIPTION
* Allow the installed ip options to be customised independently of those used to boot the IPA image (https://bugzilla.redhat.com/show_bug.cgi?id=2034527)
* Only copy the network config if that is specifically enabled (https://bugzilla.redhat.com/show_bug.cgi?id=2038303)