### PR TITLE
Move hardys to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,7 @@ approvers:
   - dtantsur
   - elfosardo
   - iurygregory
-  - hardys
   - zaneb
+
+emeritus_approvers:
+  - hardys


### PR DESCRIPTION
My area of focus has changed, so I can no longer commit to being an approver